### PR TITLE
チャットスペース自動更新の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -54,40 +54,40 @@ $(document).on('turbolinks:load', function(){
     })
   })
 
-  $(function(){
-    $(function(){
-      setInterval(update, 10000);
-    });
+  // $(function(){
+  //   $(function(){
+  //     setInterval(update, 10000);
+  //   });
 
-    function update(){
-     if($('.messages')[0]){
-     var message_id = $('.message:last').data('id');
-     }else {
-       var message_id = 0
-     }
-     $.ajax({
-       url:('/group_messages'),
-       type: 'GET',
-       data: {message: { id:message_id} },
-       dataType: 'json'
-      })
-      .always(function(data){
-        alert('自動更新来てる！');
-        $.each(data, function(i,data){
-          buildMessage(data);
-        });
-      });
-    }
-  });
+  //   function update(){
+  //    if($('.messages')[0]){
+  //    var message_id = $('.message:last').data('id');
+  //    }else {
+  //      var message_id = 0
+  //    }
+  //    $.ajax({
+  //      url:('/group_messages'),
+  //      type: 'GET',
+  //      data: {message: { id:message_id} },
+  //      dataType: 'json'
+  //     })
+  //     .always(function(data){
+  //       alert('自動更新来てる！');
+  //       $.each(data, function(i,data){
+  //         buildMessage(data);
+  //       });
+  //     });
+  //   }
+  // });
 
-  $(function(){
-    function buildMessage(message){
-      var messages = $('').append('<tr class="messages" data-id=' + message.id + '><td>' + message.text + '</td><td><a href="/messages/' + message.id + '">Show</a></td><td><a href="/messages/' + message.id +'/edit">Edit</a></td><td><a data-confirm="Are you sure?" rel="nofollow" data-method="delete" href="/messages/' + message.id + '">Destroy</a></td>')
-    }
-    $(function(){
-      setInterval(update,10000);
-    })
-  })
+  // $(function(){
+  //   function buildMessage(message){
+  //     var messages = $('').append('')
+  //   }
+  //   $(function(){
+  //     setInterval(update,10000);
+  //   })
+  // })
 
 
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,57 +1,31 @@
 $(document).on('turbolinks:load', function(){
- 
-  var buildHTML = function(message) {
-    if (message.content && message.image.url) {
-      var html = '<div class="message" data-id=' + message.id + '>' +
-        '<div class="upper-message">' +
-          '<div class="upper-message__user-name">' +
-            message.user_name +
-          '</div>' +
-          '<div class="upper-message__date">' +
-            message.created_at +
-          '</div>' +
-        '</div>' +
-        '<div class="lower-message">' +
-          '<p class="lower-message__content">' +
-            message.content +
-          '</p>' +
-          '<img src="' + message.image.url + '" class="lower-message__image" >' +
-        '</div>' +
-      '</div>'
-    } else if (message.content) {
-      var html = '<div class="message" data-id=' + message.id + '>' +
-        '<div class="upper-message">' +
-          '<div class="upper-message__user-name">' +
-            message.user_name +
-          '</div>' +
-          '<div class="upper-message__date">' +
-            message.created_at +
-          '</div>' +
-        '</div>' +
-        '<div class="lower-message">' +
-          '<p class="lower-message__content">' +
-            message.content +
-          '</p>' +
-        '</div>' +
-      '</div>'
-    } else if (message.image.url) {
-      var html = '<div class="message" data-id=' + message.id + '>' +
-        '<div class="upper-message">' +
-          '<div class="upper-message__user-name">' +
-            message.user_name +
-          '</div>' +
-          '<div class="upper-message__date">' +
-            message.created_at +
-          '</div>' +
-        '</div>' +
-        '<div class="lower-message">' +
-          '<img src="' + message.image.url + '" class="lower-message__image" >' +
-        '</div>' +
-      '</div>'
-    };
-    return html;
-  };
-
+  $(function() {
+    var createImage = function(message){
+      if(message.image.url == null){
+        return ``
+      } else {
+        return `<img class="lower-message__image" src='${message.image.url}'></img>`
+      }
+    }
+  
+    var buildHTML = function(message){
+      var html = `<div class="message" data-id="${message.id}">
+                    <div class="upper-message">
+                      <div class="upper-message__user-name">
+                        ${message.user_name}
+                      </div>
+                      <div class="upper-message__date">
+                        ${message.created_at}
+                      </div>
+                    </div>
+                    <div class="lower-message">
+                      <p class="lower-message__content">
+                        ${message.content}
+                      </p>
+                        ${createImage(message)}  
+                  </div>`
+      return html
+    }
   
   $('#new_message').on('submit', function(e){
     e.preventDefault();
@@ -102,7 +76,7 @@ $(document).on('turbolinks:load', function(){
       });
      }
     };
-    setInterval(reloadMessages, 5000);
+    setInterval(reloadMessages, 1000);
   });
-
+})
 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,13 +1,4 @@
 $(document).on('turbolinks:load', function(){
-    // debugger;
-    // var messageImage = function(message){
-    //   if(message.image.url == null){
-    //     return ``
-    //   } else {
-    //     return `<img class="lower-message__image" src='${message.image.url}'></img>`
-    //   }
-    // }
-  
     var buildHTML = function(message){
     var messageImage = message.image.url == null? 
     `` : `<img class="lower-message__image" src='${message.image.url}'></img>`;
@@ -45,8 +36,6 @@ $(document).on('turbolinks:load', function(){
     .done(function(message){
       var html = buildHTML(message);
       $('.messages').append(html)
-      $('#message_content').val('')
-      $('#message_image').val('')
       $('.send').prop('disabled', false);
       $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
       $("form")[0].reset();

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,33 +1,58 @@
 $(document).on('turbolinks:load', function(){
  
-  
-  function buildMessage(message){
-  　var img = message.image.url
-     ?  img = `<img src=${message.image.url}>`
-     :  img = ``;
-
-    var html = `<div class="message">
-                  <div class="upper-message">
-                    <div class="upper-message__user-name">
-                      ${message.user}
-                    </div>
-                    <div class="upper-message__date">
-                      ${message.date}
-                    </div>
-                  </div>
-                  <div class="lower-message">
-                    <p class="lower-message__content">
-                    ${message.content}
-                    </p> 
-                    <p class="lower-message__image">
-                    ${img}
-                    </p>
-                  </div>
-
-                </div>`
+  var buildMessage = function(message) {
+    if (message.content && message.image.url) {
+      var html = '<div class="message" data-id=' + message.id + '>' +
+        '<div class="upper-message">' +
+          '<div class="upper-message__user-name">' +
+            message.user_name +
+          '</div>' +
+          '<div class="upper-message__date">' +
+            message.created_at +
+          '</div>' +
+        '</div>' +
+        '<div class="lower-message">' +
+          '<p class="lower-message__content">' +
+            message.content +
+          '</p>' +
+          '<img src="' + message.image.url + '" class="lower-message__image" >' +
+        '</div>' +
+      '</div>'
+    } else if (message.content) {
+      var html = '<div class="message" data-id=' + message.id + '>' +
+        '<div class="upper-message">' +
+          '<div class="upper-message__user-name">' +
+            message.user_name +
+          '</div>' +
+          '<div class="upper-message__date">' +
+            message.created_at +
+          '</div>' +
+        '</div>' +
+        '<div class="lower-message">' +
+          '<p class="lower-message__content">' +
+            message.content +
+          '</p>' +
+        '</div>' +
+      '</div>'
+    } else if (message.image.url) {
+      var html = '<div class="message" data-id=' + message.id + '>' +
+        '<div class="upper-message">' +
+          '<div class="upper-message__user-name">' +
+            message.user_name +
+          '</div>' +
+          '<div class="upper-message__date">' +
+            message.created_at +
+          '</div>' +
+        '</div>' +
+        '<div class="lower-message">' +
+          '<img src="' + message.image.url + '" class="lower-message__image" >' +
+        '</div>' +
+      '</div>'
+    };
     return html;
-  }
+  };
 
+  
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -51,43 +76,61 @@ $(document).on('turbolinks:load', function(){
     .fail(function(){
       alert('エラー');
       $('.send').prop('disabled', false);
-    })
   })
-
-  // $(function(){
-  //   $(function(){
-  //     setInterval(update, 10000);
-  //   });
-
-  //   function update(){
-  //    if($('.messages')[0]){
-  //    var message_id = $('.message:last').data('id');
-  //    }else {
-  //      var message_id = 0
-  //    }
-  //    $.ajax({
-  //      url:('/group_messages'),
-  //      type: 'GET',
-  //      data: {message: { id:message_id} },
-  //      dataType: 'json'
-  //     })
-  //     .always(function(data){
-  //       alert('自動更新来てる！');
-  //       $.each(data, function(i,data){
-  //         buildMessage(data);
-  //       });
-  //     });
-  //   }
-  // });
-
-  // $(function(){
-  //   function buildMessage(message){
-  //     var messages = $('').append('')
-  //   }
-  //   $(function(){
-  //     setInterval(update,10000);
-  //   })
-  // })
+  var reloadMessages = function () {
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){
+      last_message_id = $('.message:last').data("id");
+      //last_message_idガ定義されていない
+      console.log(last_message_id);
+      $.ajax({ 
+        url: "api/messages", 
+        type: 'get', 
+        dataType: 'json', 
+        data: {id: last_message_id} 
+      })
+      .done(function (messages) {
+        alert('インターバル機能は動いていますが、、、、、、、');
+        var insertHTML = '';
+        messages.forEach(function (message) {
+          insertHTML = buildHTML(message); 
+          $('.messages').append(insertHTML);
+        })
+        $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+      })
+      .fail(function () {
+        alert('自動更新に失敗しました');
+      });
+     }
+    };
+    setInterval(reloadMessages, 10000);
+   });
+  });
 
 
-});
+
+
+
+
+// var reloadMessages = function(){
+//   last_message_id = $('.message:last')
+//   $.ajax({
+//     url: 'api/messages',
+//     type:'GET',
+//     datatype: 'json',
+//     data: {id: last_message_id}
+//   })
+//   .done(function(messages){
+//     alert('success');
+//     var insertHTML = '';
+//     messages.forEach(function(user){
+//     var html = reloadMessages(user);
+//     $('.messages').append(html);
+//     })
+//   })
+//   .fail(function(){
+//     alert('error');
+//   });
+// $(function(){
+//     setInterval(reloadMessages, 5000);
+// })
+// };

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -77,6 +77,7 @@ $(document).on('turbolinks:load', function(){
       alert('エラー');
       $('.send').prop('disabled', false);
   })
+
   var reloadMessages = function () {
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
       last_message_id = $('.message:last').data("id");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -53,4 +53,41 @@ $(document).on('turbolinks:load', function(){
       $('.send').prop('disabled', false);
     })
   })
+
+  $(function(){
+    $(function(){
+      setInterval(update, 10000);
+    });
+
+    function update(){
+     if($('.messages')[0]){
+     var message_id = $('.message:last').data('id');
+     }else {
+       var message_id = 0
+     }
+     $.ajax({
+       url:('/group_messages'),
+       type: 'GET',
+       data: {message: { id:message_id} },
+       dataType: 'json'
+      })
+      .always(function(data){
+        alert('自動更新来てる！');
+        $.each(data, function(i,data){
+          buildMessage(data);
+        });
+      });
+    }
+  });
+
+  $(function(){
+    function buildMessage(message){
+      var messages = $('').append('<tr class="messages" data-id=' + message.id + '><td>' + message.text + '</td><td><a href="/messages/' + message.id + '">Show</a></td><td><a href="/messages/' + message.id +'/edit">Edit</a></td><td><a data-confirm="Are you sure?" rel="nofollow" data-method="delete" href="/messages/' + message.id + '">Destroy</a></td>')
+    }
+    $(function(){
+      setInterval(update,10000);
+    })
+  })
+
+
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -81,13 +81,13 @@ $(document).on('turbolinks:load', function(){
   var reloadMessages = function () {
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
       last_message_id = $('.message:last').data("id");
+      //last_message_idガ定義されていない
       console.log(last_message_id);
       $.ajax({ 
         url: "api/messages", 
-        type: 'GET', 
+        type: 'get', 
         dataType: 'json', 
-        data: {message: { id:message_id} }
-        // {id: last_message_id} 
+        data: {id: last_message_id} 
       })
       .done(function (messages) {
         alert('インターバル機能は動いていますが、、、、、、、');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -76,20 +76,22 @@ $(document).on('turbolinks:load', function(){
     .fail(function(){
       alert('エラー');
       $('.send').prop('disabled', false);
-  })
+    })
+  });
 
   var reloadMessages = function () {
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
+      console.log('if まで来ました');
       last_message_id = $('.message:last').data("id");
       console.log(last_message_id);
       $.ajax({ 
         url: "api/messages", 
-        type: 'get', 
+        type: 'GET', 
         dataType: 'json', 
         data: {id: last_message_id} 
       })
       .done(function (messages) {
-        alert('インターバル機能は動いていますが、、、、、、、');
+        console.log('ようやくdone来ました');
         var insertHTML = '';
         messages.forEach(function (message) {
           insertHTML = buildHTML(message); 
@@ -98,39 +100,12 @@ $(document).on('turbolinks:load', function(){
         $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
       })
       .fail(function () {
-        alert('自動更新に失敗しました');
+        console.log("failです");
+        // alert('自動更新に失敗しました');
       });
      }
     };
-    setInterval(reloadMessages, 10000);
-   });
+    setInterval(reloadMessages, 5000);
   });
 
 
-
-
-
-
-// var reloadMessages = function(){
-//   last_message_id = $('.message:last')
-//   $.ajax({
-//     url: 'api/messages',
-//     type:'GET',
-//     datatype: 'json',
-//     data: {id: last_message_id}
-//   })
-//   .done(function(messages){
-//     alert('success');
-//     var insertHTML = '';
-//     messages.forEach(function(user){
-//     var html = reloadMessages(user);
-//     $('.messages').append(html);
-//     })
-//   })
-//   .fail(function(){
-//     alert('error');
-//   });
-// $(function(){
-//     setInterval(reloadMessages, 5000);
-// })
-// };

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,32 +1,35 @@
 $(document).on('turbolinks:load', function(){
-  $(function() {
-    var createImage = function(message){
-      if(message.image.url == null){
-        return ``
-      } else {
-        return `<img class="lower-message__image" src='${message.image.url}'></img>`
-      }
-    }
+    // debugger;
+    // var messageImage = function(message){
+    //   if(message.image.url == null){
+    //     return ``
+    //   } else {
+    //     return `<img class="lower-message__image" src='${message.image.url}'></img>`
+    //   }
+    // }
   
     var buildHTML = function(message){
-      var html = `<div class="message" data-id="${message.id}">
-                    <div class="upper-message">
-                      <div class="upper-message__user-name">
-                        ${message.user_name}
-                      </div>
-                      <div class="upper-message__date">
-                        ${message.created_at}
-                      </div>
+    var messageImage = message.image.url == null? 
+    `` : `<img class="lower-message__image" src='${message.image.url}'></img>`;
+
+    var html = `<div class="message" data-id="${message.id}">
+                  <div class="upper-message">
+                    <div class="upper-message__user-name">
+                      ${message.user_name}
                     </div>
-                    <div class="lower-message">
-                      <p class="lower-message__content">
-                        ${message.content}
-                      </p>
-                        ${createImage(message)}  
-                  </div>`
+                    <div class="upper-message__date">
+                      ${message.created_at}
+                    </div>
+                  </div>
+                  <div class="lower-message">
+                    <p class="lower-message__content">
+                      ${message.content}
+                    </p>
+                      ${messageImage}  
+                </div>`
       return html
     }
-  
+
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -46,6 +49,7 @@ $(document).on('turbolinks:load', function(){
       $('#message_image').val('')
       $('.send').prop('disabled', false);
       $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      $("form")[0].reset();
     })
     .fail(function(){
       alert('エラー');
@@ -78,5 +82,4 @@ $(document).on('turbolinks:load', function(){
     };
     setInterval(reloadMessages, 1000);
   });
-})
 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -81,13 +81,13 @@ $(document).on('turbolinks:load', function(){
   var reloadMessages = function () {
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
       last_message_id = $('.message:last').data("id");
-      //last_message_idガ定義されていない
       console.log(last_message_id);
       $.ajax({ 
         url: "api/messages", 
-        type: 'get', 
+        type: 'GET', 
         dataType: 'json', 
-        data: {id: last_message_id} 
+        data: {message: { id:message_id} }
+        // {id: last_message_id} 
       })
       .done(function (messages) {
         alert('インターバル機能は動いていますが、、、、、、、');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,6 @@
 $(document).on('turbolinks:load', function(){
  
-  var buildMessage = function(message) {
+  var buildHTML = function(message) {
     if (message.content && message.image.url) {
       var html = '<div class="message" data-id=' + message.id + '>' +
         '<div class="upper-message">' +
@@ -66,7 +66,7 @@ $(document).on('turbolinks:load', function(){
       contentType: false
     })
     .done(function(message){
-      var html = buildMessage(message);
+      var html = buildHTML(message);
       $('.messages').append(html)
       $('#message_content').val('')
       $('#message_image').val('')
@@ -81,27 +81,24 @@ $(document).on('turbolinks:load', function(){
 
   var reloadMessages = function () {
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
-      console.log('if まで来ました');
       last_message_id = $('.message:last').data("id");
-      console.log(last_message_id);
       $.ajax({ 
         url: "api/messages", 
         type: 'GET', 
         dataType: 'json', 
-        data: {id: last_message_id} 
+        data: {last_id: last_message_id} 
       })
       .done(function (messages) {
-        console.log('ようやくdone来ました');
         var insertHTML = '';
         messages.forEach(function (message) {
           insertHTML = buildHTML(message); 
           $('.messages').append(insertHTML);
-        })
+          })
+        
         $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
       })
       .fail(function () {
-        console.log("failです");
-        // alert('自動更新に失敗しました');
+        alert('自動更新に失敗しました');
       });
      }
     };

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -81,7 +81,6 @@ $(document).on('turbolinks:load', function(){
   var reloadMessages = function () {
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
       last_message_id = $('.message:last').data("id");
-      //last_message_idガ定義されていない
       console.log(last_message_id);
       $.ajax({ 
         url: "api/messages", 

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,13 +1,6 @@
 class Api::MessagesController < ApplicationController
   def index
     @group = Group.find(params[:group_id])
-    @messages = @group.messages.includes(:user).where('id > ?', params[:last_message_id]) 
+    @messages = @group.messages.includes(:user).where('id > ?', params[:last_id]) 
   end
 end
-
-# @messages = Message.all 
-# @message = Message.where('id > ?',params[:message][:id])
-# respond_to do |format|
-#  format.html
-#  format.json 
-# end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,7 +1,7 @@
 class Api::MessagesController < ApplicationController
   def index
     @group = Group.find(params[:group_id])
-    @messages = @group.messages.includes(:user).where('id > ?', params[:message][:id]) 
+    @messages = @group.messages.includes(:user).where('id > ?', params[:message][:id])
   end
 end
 

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,10 +1,9 @@
 class Api::MessagesController < ApplicationController
   def index
     @group = Group.find(params[:group_id])
-    @messages = @group.messages.includes(:user).where('id > ?', params[:message][:id]) 
+    @messages = @group.messages.includes(:user).where('id > ?', params[:last_message_id]) 
   end
 end
-
 
 # @messages = Message.all 
 # @message = Message.where('id > ?',params[:message][:id])

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,9 +1,14 @@
 class Api::MessagesController < ApplicationController
   def index
-   @message = Message.all 
-   respond_to do |format|
-    format.html
-    format.json { @new_message = Message.where('id > ?',params[:message][:id])}
-   end
+    @group = Group.find(params[:group_id])
+    @messages = @group.messages.includes(:user).where('id > ?', params[:message][:id]) 
   end
 end
+
+
+# @messages = Message.all 
+# @message = Message.where('id > ?',params[:message][:id])
+# respond_to do |format|
+#  format.html
+#  format.json 
+# end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,9 @@
+class Api::MessagesController < ApplicationController
+  def index
+   @message = Message.all 
+   respond_to do |format|
+    format.html
+    format.json { @new_message = Message.where('id > ?',params[:message][:id])}
+   end
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,7 +1,7 @@
 class Api::MessagesController < ApplicationController
   def index
     @group = Group.find(params[:group_id])
-    @messages = @group.messages.includes(:user).where('id > ?', params[:message][:id])
+    @messages = @group.messages.includes(:user).where('id > ?', params[:message][:id]) 
   end
 end
 

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,16 +1,7 @@
 json.array! @messages do |message|
   json.content message.content
   json.image message.image
-  json.created_at message.created_at
+  json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
   json.user_name message.user.name
   json.id message.id
 end
-
-
-
-# json.array! @messages do |message|
-#   json.(message, :content, :image)
-#   json.created_at message.created_at
-#   json.user_name message.user.name
-#   json.id message.id
-# end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,13 +1,16 @@
 json.array! @messages do |message|
   json.content message.content
   json.image message.image
-  json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
-  json.user.name message.user.name
+  json.created_at message.created_at
+  json.user_name message.user.name
   json.id message.id
 end
 
 
-# if @new_message.present?
-#   json.array! @new_message
+
+# json.array! @messages do |message|
+#   json.(message, :content, :image)
+#   json.created_at message.created_at
+#   json.user_name message.user.name
+#   json.id message.id
 # end
-# 上の＠messagesは違う可能性があるな

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -2,7 +2,7 @@ json.array! @messages do |message|
   json.content message.content
   json.image message.image
   json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
-  json.user.name message.user.name
+  json.user_name message.user.name
   json.id message.id
 end
 

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -2,7 +2,7 @@ json.array! @messages do |message|
   json.content message.content
   json.image message.image
   json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
-  json.user_name message.user.name
+  json.user.name message.user.name
   json.id message.id
 end
 

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,8 +1,8 @@
 json.array! @messages do |message|
   json.content message.content
   json.image message.image
-  json.created_at message.created_at
-  json.user_name message.user.name
+  json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user.name message.user.name
   json.id message.id
 end
 
@@ -10,3 +10,4 @@ end
 # if @new_message.present?
 #   json.array! @new_message
 # end
+# 上の＠messagesは違う可能性があるな

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,12 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at
+  json.user_name message.user.name
+  json.id message.id
+end
+
+
+# if @new_message.present?
+#   json.array! @new_message
+# end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -4,4 +4,5 @@ json.array! @messages do |message|
   json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
   json.user_name message.user.name
   json.id message.id
+  # json.image.url message.image.url
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,5 +1,5 @@
 
-.message
+.message{ data: {'id': 'message.id'}}
   .upper-message
     .upper-message__user-name
       = message.user.name
@@ -10,3 +10,5 @@
       %p.lower-message__content
         = message.content
     = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+
+

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message{ 'data-id': "message.id"}
+.message{ 'data-id': "#{message.id}"}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,9 @@
+<<<<<<< HEAD
 .message{ 'data-id': "message.id"}
+=======
+
+.message
+>>>>>>> parent of 640ac2a... 一旦サイトから自動リクエストまで完了
   .upper-message
     .upper-message__user-name
       = message.user.name
@@ -9,3 +14,13 @@
       %p.lower-message__content
         = message.content
     = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+<<<<<<< HEAD
+
+
+
+
+
+-# { data: {'id': 'message.id'}}
+
+=======
+>>>>>>> parent of 640ac2a... 一旦サイトから自動リクエストまで完了

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,5 +1,4 @@
-
-.message{ data: {'id': 'message.id'}}
+.message{ 'data-id': "message.id"}
   .upper-message
     .upper-message__user-name
       = message.user.name
@@ -11,4 +10,9 @@
         = message.content
     = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
 
+
+
+
+
+-# { data: {'id': 'message.id'}}
 

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,9 @@
+<<<<<<< HEAD
 .message{ 'data-id': "message.id"}
+=======
+
+.message
+>>>>>>> parent of 640ac2a... 一旦サイトから自動リクエストまで完了
   .upper-message
     .upper-message__user-name
       = message.user.name
@@ -9,6 +14,7 @@
       %p.lower-message__content
         = message.content
     = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+<<<<<<< HEAD
 
 
 
@@ -16,3 +22,5 @@
 
 -# { data: {'id': 'message.id'}}
 
+=======
+>>>>>>> parent of 640ac2a... 一旦サイトから自動リクエストまで完了

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,9 +1,4 @@
-<<<<<<< HEAD
 .message{ 'data-id': "message.id"}
-=======
-
-.message
->>>>>>> parent of 640ac2a... 一旦サイトから自動リクエストまで完了
   .upper-message
     .upper-message__user-name
       = message.user.name
@@ -14,13 +9,3 @@
       %p.lower-message__content
         = message.content
     = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
-<<<<<<< HEAD
-
-
-
-
-
--# { data: {'id': 'message.id'}}
-
-=======
->>>>>>> parent of 640ac2a... 一旦サイトから自動リクエストまで完了

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user @message.user.name
 json.content @message.content
 json.date @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.image @message.image
+json.id @message.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.(@message, :content, :image)
 json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.user_name @message.user.name
 json.id @message.id
+

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,9 +2,3 @@ json.(@message, :content, :image)
 json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.user_name @message.user.name
 json.id @message.id
-
-# json.user @message.user.name
-# json.content @message.content
-# json.date @message.created_at.strftime("%Y/%m/%d %H:%M")
-# json.image @message.image
-# json.id @message.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,10 @@
-json.user @message.user.name
-json.content @message.content
-json.date @message.created_at.strftime("%Y/%m/%d %H:%M")
-json.image @message.image
+json.(@message, :content, :image)
+json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.user_name @message.user.name
 json.id @message.id
+
+# json.user @message.user.name
+# json.content @message.content
+# json.date @message.created_at.strftime("%Y/%m/%d %H:%M")
+# json.image @message.image
+# json.id @message.id

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,0 +1,3 @@
+if @new_message.present?
+  json.array! @new_message
+end

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,3 +1,0 @@
-if @new_message.present?
-  json.array! @new_message
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,13 @@ Rails.application.routes.draw do
   resources :users, only:[:index, :edit, :update]
   resources :groups,only:[:new, :create, :edit, :update] do
    resources :messages, only: [:index, :create]
+<<<<<<< HEAD
+  
+   namespace :api do
+     resources :messages, only: :index, defaults: { format: 'json' }
+   end
+=======
+>>>>>>> parent of 640ac2a... 一旦サイトから自動リクエストまで完了
   end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,13 +4,9 @@ Rails.application.routes.draw do
   resources :users, only:[:index, :edit, :update]
   resources :groups,only:[:new, :create, :edit, :update] do
    resources :messages, only: [:index, :create]
-<<<<<<< HEAD
-  
    namespace :api do
      resources :messages, only: :index, defaults: { format: 'json' }
    end
-=======
->>>>>>> parent of 640ac2a... 一旦サイトから自動リクエストまで完了
   end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,8 @@ Rails.application.routes.draw do
    resources :messages, only: [:index, :create]
   
    namespace :api do
-  　　resources :messages, only: :index, defaults: { format: 'json' }
-  　end
+     resources :messages, only: :index, defaults: { format: 'json' }
+   end
   end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,13 @@ Rails.application.routes.draw do
   resources :users, only:[:index, :edit, :update]
   resources :groups,only:[:new, :create, :edit, :update] do
    resources :messages, only: [:index, :create]
+<<<<<<< HEAD
   
    namespace :api do
      resources :messages, only: :index, defaults: { format: 'json' }
    end
+=======
+>>>>>>> parent of 640ac2a... 一旦サイトから自動リクエストまで完了
   end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
   resources :users, only:[:index, :edit, :update, :create]
   resources :groups,only:[:index, :new, :create, :edit, :update] do
    resources :messages, only: [:index, :create]
+  
+  #  namespace :api do
+  # 　　resources :messages, only: :index, defaults: { format: 'json' }
+  # 　end
   end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,13 @@
 Rails.application.routes.draw do
   devise_for :users
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root to: 'groups#index'
-  resources :users, only:[:index, :edit, :update, :create]
-  resources :groups,only:[:index, :new, :create, :edit, :update] do
+  root 'groups#index'
+  resources :users, only:[:index, :edit, :update]
+  resources :groups,only:[:new, :create, :edit, :update] do
    resources :messages, only: [:index, :create]
   
-  #  namespace :api do
-  # 　　resources :messages, only: :index, defaults: { format: 'json' }
-  # 　end
+   namespace :api do
+  　　resources :messages, only: :index, defaults: { format: 'json' }
+  　end
   end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,13 +4,6 @@ Rails.application.routes.draw do
   resources :users, only:[:index, :edit, :update]
   resources :groups,only:[:new, :create, :edit, :update] do
    resources :messages, only: [:index, :create]
-<<<<<<< HEAD
-  
-   namespace :api do
-     resources :messages, only: :index, defaults: { format: 'json' }
-   end
-=======
->>>>>>> parent of 640ac2a... 一旦サイトから自動リクエストまで完了
   end
 end
 


### PR DESCRIPTION
#WHAT
チャットスペースの非同期通信による自動更新の実装

#WHY
非同期通信にすることでサーバーへの負担を少なくし
常に最新の状態を画面に表示させることで本来のチャット機能の充実を図るため